### PR TITLE
:sparkles: allow illuminate v9 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^7.0|^8.0",
-        "illuminate/http": "^7.0|^8.0",
-        "illuminate/contracts": "^7.0|^8.0",
+        "illuminate/support": "^7.0|^8.0|^9.0",
+        "illuminate/http": "^7.0|^8.0|^9.0",
+        "illuminate/contracts": "^7.0|^8.0|^9.0",
         "guzzlehttp/guzzle": "^7.0",
         "spatie/data-transfer-object": "^2.0"
     },


### PR DESCRIPTION
Hi there :)
This change is required to use this useful package inside laravel 9 application. Tell me if something else has to be done to be released. Thanks in advance