### PR TITLE
Manage addresses - V2 using camel case notation

### DIFF
--- a/src/Api/CompaniesAddressesApi.php
+++ b/src/Api/CompaniesAddressesApi.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\AddressCollection;
+use Bluerock\Sellsy\Entities\Address;
+use Bluerock\Sellsy\Entities\Company;
+
+/**
+ * The API client for the `addresses` namespace in Companies
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ * @see https://api.sellsy.com/doc/v2/#tag/Companies
+ */
+class CompaniesAddressesApi extends GenericAddressesApi
+{
+    /**
+     * The Api class constructor, setting up common tools.
+	 * Package:
+	 * bluerock/sellsy-client
+	 *
+	 * @param Company $company		The company
+     */
+    public function __construct(Company $company)
+    {
+        parent::__construct($company);
+        $this->entity     = Address::class;
+        $this->collection = AddressCollection::class;
+    }
+}

--- a/src/Api/CompaniesApi.php
+++ b/src/Api/CompaniesApi.php
@@ -2,6 +2,7 @@
 
 namespace Bluerock\Sellsy\Api;
 
+use Bluerock\Sellsy\Entities\Address;
 use Bluerock\Sellsy\Entities\Company;
 use Bluerock\Sellsy\Collections\CompanyCollection;
 use Bluerock\Sellsy\Core\Response;
@@ -140,4 +141,106 @@ class CompaniesApi extends AbstractApi
 
         return $this->prepareResponse($response);
     }
+
+	/**
+	 * List all addresses.
+	 *
+	 * @param Company $company The company entity to use
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-company-addresses
+	 */
+	public function indexAddress(Company $company, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("companies/{$company->id}/addresses")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Show a single address by id.
+	 *
+	 * @param Company $company    The company entity to use
+	 * @param string  $id         The address id to retrieve.
+	 * @param array  $query  Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-company-address
+	 *
+	 */
+	public function showAddress(Company $company, string $id, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("companies/{$company->id}/addresses/{$id}")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Store (create) an address.
+	 *
+	 * @param Company $company    The company entity to use
+	 * @param Address $address    The address entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/create-company-address
+	 */
+	public function storeAddress(Company $company, Address $address, array $query = []): Response
+	{
+		$body = $address->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("companies/{$company->id}/addresses")
+			->post(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Update an existing address.
+	 *
+	 * @param Company $company    The company entity to use
+	 * @param Address $address    The address entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-company-address
+	 */
+	public function updateAddress(Company $company, Address $address, array $query = []): Response
+	{
+		$body = $address->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("companies/{$company->id}/addresses/{$address->id}")
+			->put(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Delete an existing address.
+	 *
+	 * @param Company $company    The company entity to use
+	 * @param int     $id         The address id to be deleted.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/delete-company-address
+	 */
+	public function destroyAddress(Company $company, int $id): Response
+	{
+		$response = $this->connection
+			->request("companies/{$company->id}/addresses/{$id}")
+			->delete();
+
+		return $this->prepareResponse($response);
+	}
 }

--- a/src/Api/ContactsAddressesApi.php
+++ b/src/Api/ContactsAddressesApi.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\AddressCollection;
+use Bluerock\Sellsy\Entities\Address;
+use Bluerock\Sellsy\Entities\Contact;
+
+/**
+ * The API client for the `addresses` namespace in Contacts
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ * @see https://api.sellsy.com/doc/v2/#tag/Contacts
+ */
+class ContactsAddressesApi extends GenericAddressesApi
+{
+    /**
+     * The Api class constructor, setting up common tools.
+	 * Package:
+	 * bluerock/sellsy-client
+	 *
+	 * @param Contact $contact		The contact
+     */
+    public function __construct(Contact $contact)
+    {
+        parent::__construct($contact);
+        $this->entity     = Address::class;
+        $this->collection = AddressCollection::class;
+    }
+}

--- a/src/Api/ContactsApi.php
+++ b/src/Api/ContactsApi.php
@@ -3,6 +3,7 @@
 namespace Bluerock\Sellsy\Api;
 
 use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Entities\Address;
 use Bluerock\Sellsy\Entities\Contact;
 use Bluerock\Sellsy\Collections\ContactCollection;
 
@@ -141,4 +142,106 @@ class ContactsApi extends AbstractApi
 
         return $this->prepareResponse($response);
     }
+
+	/**
+	 * List all addresses.
+	 *
+	 * @param Contact $contact    The contact entity to use
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-addresses
+	 */
+	public function indexAddress(Contact $contact, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("contacts/{$contact->id}/addresses")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Show a single address by id.
+	 *
+	 * @param Contact $contact    The contact entity to use
+	 * @param string  $id         The address id to retrieve.
+	 * @param array  $query  Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-address
+	 *
+	 */
+	public function showAddress(Contact $contact, string $id, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("contacts/{$contact->id}/addresses/{$id}")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Store (create) an address.
+	 *
+	 * @param Contact $contact    The contact entity to use
+	 * @param Address $address    The address entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/create-contact-address
+	 */
+	public function storeAddress(Contact $contact, Address $address, array $query = []): Response
+	{
+		$body = $address->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("contacts/{$contact->id}/addresses")
+			->post(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Update an existing address.
+	 *
+	 * @param Contact $contact    The contact entity to use
+	 * @param Address $address    The address entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-contact-address
+	 */
+	public function updateAddress(Contact $contact, Address $address, array $query = []): Response
+	{
+		$body = $address->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("contacts/{$contact->id}/addresses/{$address->id}")
+			->put(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Delete an existing address.
+	 *
+	 * @param Contact $contact    The contact entity to use
+	 * @param int     $id         The address id to be deleted.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/delete-contact-address
+	 */
+	public function destroyAddress(Contact $contact, int $id): Response
+	{
+		$response = $this->connection
+			->request("contacts/{$contact->id}/addresses/{$id}")
+			->delete();
+
+		return $this->prepareResponse($response);
+	}
 }

--- a/src/Api/GenericAddressesApi.php
+++ b/src/Api/GenericAddressesApi.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Entities\Address;
+use Bluerock\Sellsy\Entities\Client;
+use Bluerock\Sellsy\Entities\Company;
+use Bluerock\Sellsy\Entities\Contact;
+use Bluerock\Sellsy\Entities\Entity;
+use Bluerock\Sellsy\Exceptions\ApiClientErrorException;
+
+/**
+ * The API client for the `addresses` namespace.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ * @see https://api.sellsy.com/doc/v2/#tag/Companies
+ */
+class GenericAddressesApi extends AbstractApi
+{
+	/**
+	 * @var Client 	entity containing addresses
+	 */
+	protected $parentEntity;
+
+
+	/**
+	 * @var string entity type (Sellsy api endpoint)
+	 */
+	protected $sellsyEntityType;
+
+
+    /**
+     * The Api class constructor, setting up common tools.
+	 * Package:
+	 * bluerock/sellsy-client
+	 *
+	 * @param Entiyt	The parent entity
+     */
+    public function __construct(Entity $parentEntity)
+    {
+        parent::__construct();
+
+		// Only clients witch can hold addresses
+		if ($parentEntity instanceof Company) {
+			$this->sellsyEntityType = 'companies';
+		} elseif ($parentEntity instanceof Contact) {
+			$this->sellsyEntityType = 'contacts';
+		} elseif ($parentEntity instanceof Individual) {
+			$this->sellsyEntityType = 'individuals';
+		} else {
+			throw new ApiClientErrorException(\sprintf('%s class not implemented. Can\'t have addresses?', \get_class($parentEntity)));
+		}
+        $this->collection = AddressCollection::class;
+		$this->parentEntity = $parentEntity;
+    }
+
+    /**
+     * List all addresses.
+     *
+     * @param array $query Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/get-company-addresses
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-addresses
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-addresses
+     */
+    public function index(array $query = []): Response
+    {
+        $response = $this->connection
+                        ->request("{$this->sellsyEntityType}/{$this->parentEntity->id}/addresses")
+                        ->get($query);
+
+        return $this->prepareResponse($response);
+    }
+
+    /**
+     * Show a single address by id.
+     *
+     * @param string $id     The address id to retrieve.
+     * @param array  $query  Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/get-company-address
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-address
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-address
+	 *
+     */
+    public function show(string $id, array $query = []): Response
+    {
+        $response = $this->connection
+                        ->request("{$this->sellsyEntityType}/{$this->parentEntity->id}/addresses/{$id}")
+                        ->get($query);
+
+        return $this->prepareResponse($response);
+    }
+
+    /**
+     * Store (create) an address.
+     *
+     * @param Address $address The address entity to store.
+     * @param array   $query   Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/create-company-address
+	 * @see https://api.sellsy.com/doc/v2/#operation/create-contact-address
+	 * @see https://api.sellsy.com/doc/v2/#operation/create-individual-address
+     */
+    public function store(Address $address, array $query = []): Response
+    {
+        $body = $address->except('id')
+                        ->except('owner')
+                        ->toArray();
+
+        $response = $this->connection
+                        ->request("{$this->sellsyEntityType}/{$this->parentEntity->id}/addresses")
+                        ->post(array_filter($body) + $query);
+
+        return $this->prepareResponse($response);
+    }
+
+    /**
+     * Update an existing address.
+     *
+     * @param Address $address The address entity to store.
+     * @param array   $query   Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/update-company-address
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-contact-address
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-individual-address
+     */
+    public function update(Address $address, array $query = []): Response
+    {
+        $body = $address->except('id')
+                        ->except('owner')
+                        ->toArray();
+
+        $response = $this->connection
+                        ->request("{$this->sellsyEntityType}/{$this->parentEntity->id}/addresses/{$address->id}")
+                        ->put(array_filter($body) + $query);
+
+        return $this->prepareResponse($response);
+    }
+
+    /**
+     * Delete an existing address.
+     *
+     * @param int $id The address id to be deleted.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/delete-company-address
+     */
+    public function destroy(int $id): Response
+    {
+        $response = $this->connection
+                        ->request("{$this->sellsyEntityType}/{$this->parentEntity->id}/addresses/{$id}")
+                        ->delete();
+
+        return $this->prepareResponse($response);
+    }
+}

--- a/src/Api/IndividualsAddressesApi.php
+++ b/src/Api/IndividualsAddressesApi.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\AddressCollection;
+use Bluerock\Sellsy\Entities\Address;
+use Bluerock\Sellsy\Entities\Individual;
+
+/**
+ * The API client for the `addresses` namespace in Individuals
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ * @see https://api.sellsy.com/doc/v2/#tag/Individuals
+ */
+class IndividualsAddressesApi extends GenericAddressesApi
+{
+    /**
+     * The Api class constructor, setting up common tools.
+	 * Package:
+	 * bluerock/sellsy-client
+	 *
+	 * @param Individual $individual		The individual
+     */
+    public function __construct(Individual $individual)
+    {
+        parent::__construct($individual);
+        $this->entity     = Address::class;
+        $this->collection = AddressCollection::class;
+    }
+}

--- a/src/Api/IndividualsApi.php
+++ b/src/Api/IndividualsApi.php
@@ -2,6 +2,8 @@
 
 namespace Bluerock\Sellsy\Api;
 
+use Bluerock\Sellsy\Entities\Address;
+use Bluerock\Sellsy\Entities\Contact;
 use Bluerock\Sellsy\Entities\Individual;
 use Bluerock\Sellsy\Collections\IndividualCollection;
 use Bluerock\Sellsy\Core\Response;
@@ -140,4 +142,106 @@ class IndividualsApi extends AbstractApi
 
         return $this->prepareResponse($response);
     }
+
+	/**
+	 * List all addresses.
+	 *
+	 * @param Individual $individual    The individual entity to use
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-addresses
+	 */
+	public function indexAddress(Individual $individual, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("individuals/{$individual->id}/addresses")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Show a single address by id.
+	 *
+	 * @param Individual $individual    The individual entity to use
+	 * @param string  $id               The address id to retrieve.
+	 * @param array  $query  Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-address
+	 *
+	 */
+	public function showAddress(Individual $individual, string $id, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("individuals/{$individual->id}/addresses/{$id}")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Store (create) an address.
+	 *
+	 * @param Individual $individual    The individual entity to use
+	 * @param Address $address          The address entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/create-individual-address
+	 */
+	public function storeAddress(Individual $individual, Address $address, array $query = []): Response
+	{
+		$body = $address->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("individuals/{$individual->id}/addresses")
+			->post(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Update an existing address.
+	 *
+	 * @param Individual $individual    The individual entity to use
+	 * @param Address $address          The address entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-individual-address
+	 */
+	public function updateAddress(Individual $individual, Address $address, array $query = []): Response
+	{
+		$body = $address->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("individuals/{$individual->id}/addresses/{$address->id}")
+			->put(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Delete an existing address.
+	 *
+	 * @param Individual $individual    The individual entity to use
+	 * @param int     $id               The address id to be deleted.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/delete-individual-address
+	 */
+	public function destroyAddress(Contact $contact, int $id): Response
+	{
+		$response = $this->connection
+			->request("individuals/{$contact->id}/addresses/{$id}")
+			->delete();
+
+		return $this->prepareResponse($response);
+	}
 }

--- a/src/Collections/AddressCollection.php
+++ b/src/Collections/AddressCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Collections;
+
+use Bluerock\Sellsy\Entities\Address;
+use Bluerock\Sellsy\Contracts\EntityCollectionContract;
+use Spatie\DataTransferObject\DataTransferObjectCollection;
+
+/**
+ * The Address Entity collection.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.0
+ * @access public
+ *
+ * @method \Bluerock\Sellsy\Entities\Address current
+ */
+class AddressCollection extends DataTransferObjectCollection implements EntityCollectionContract
+{
+    public static function create(array $data): AddressCollection
+    {
+        return new static(Address::arrayOf($data));
+    }
+}

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -104,7 +104,8 @@ class Response
     public function json(): ?array
     {
         $data = $this->resp->json();
-
+		if (null === $data)
+			return $data;
         if (isset($data['data'])) {
             $data['data'] = array_map([$this, 'parseEmbed'], $data['data']);
         }


### PR DESCRIPTION
Here is another try of address management, adding methods to existing APIs, like this:
```php
CompaniesApi::indexAddress($company, $query)
CompaniesApi::showAddress($company, $id_address, $query)
CompaniesApi::storeAddress($company, $address, $query)
CompaniesApi::updateAddress($company, $address, $query)
CompaniesApi::destroyAddress($company, $id_address)
```
I read on your README.md that it was the recommended way of doing, but it was too late I already pushed the 1st PR :'(