### PR TITLE
Add favourite filters + entity contact management

### DIFF
--- a/src/Api/CompaniesApi.php
+++ b/src/Api/CompaniesApi.php
@@ -15,8 +15,11 @@ use Bluerock\Sellsy\Core\Response;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Companies
  */
-class CompaniesApi extends AbstractApi
+class CompaniesApi extends AbstractApi implements Contracts\HasContactsApi, Contracts\HasFavouriteFiltersApi
 {
+	use Concerns\CanManageContactsApi,
+		Concerns\CanManageFavouriteFiltersApi;
+
     /**
      * @inheritdoc
      */

--- a/src/Api/Concerns/CanManageContactsApi.php
+++ b/src/Api/Concerns/CanManageContactsApi.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access public
+ */
+trait CanManageContactsApi
+{
+	/**
+	 * Give the favourite filters
+	 *
+	 * @return Api\EntityContactsApi
+	 */
+	public function contacts(): Api\EntityContactsApi
+	{
+		return new Api\EntityContactsApi($this);
+	}
+}

--- a/src/Api/Concerns/CanManageFavouriteFiltersApi.php
+++ b/src/Api/Concerns/CanManageFavouriteFiltersApi.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access public
+ */
+trait CanManageFavouriteFiltersApi
+{
+	/**
+	 * Give the favourite filters
+	 *
+	 * @return Api\EntityFavouriteFiltersApi
+	 */
+	public function favouriteFilters(): Api\EntityFavouriteFiltersApi
+	{
+		return new Api\EntityFavouriteFiltersApi($this);
+	}
+}

--- a/src/Api/ContactsApi.php
+++ b/src/Api/ContactsApi.php
@@ -15,8 +15,10 @@ use Bluerock\Sellsy\Collections\ContactCollection;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Contacts
  */
-class ContactsApi extends AbstractApi
+class ContactsApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi
 {
+	use Concerns\CanManageFavouriteFiltersApi;
+
     /**
      * @inheritdoc
      */
@@ -141,4 +143,23 @@ class ContactsApi extends AbstractApi
 
         return $this->prepareResponse($response);
     }
+
+
+	/**
+	 * Get companies of the contact by id.
+	 *
+	 * @param string $id     The contact id to use.
+	 * @param array  $query  Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-companies
+	 */
+	public function companies(string $id, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("contacts/{$id}/companies")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
 }

--- a/src/Api/Contracts/HasContactsApi.php
+++ b/src/Api/Contracts/HasContactsApi.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Contracts;
+
+/**
+ * The contacts API contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+interface HasContactsApi
+{
+}

--- a/src/Api/Contracts/HasFavouriteFiltersApi.php
+++ b/src/Api/Contracts/HasFavouriteFiltersApi.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Contracts;
+
+/**
+ * The favourite filters API contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+interface HasFavouriteFiltersApi
+{
+}

--- a/src/Api/EntityContactsApi.php
+++ b/src/Api/EntityContactsApi.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\ContactCollection;
+use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Api\Contracts\HasContactsApi;
+use Bluerock\Sellsy\Entities\Contracts\HasContacts;
+use Bluerock\Sellsy\Entities\Contact;
+use Illuminate\Support\Str;
+
+/**
+ * The API client for the contact management of different entity type.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ */
+class EntityContactsApi extends AbstractApi
+{
+	/**
+	 * @var HasContacts The related entity owning the contacts.
+	 */
+	protected $relatedEntity;
+
+	/**
+	 * @var string The related entity base endpoint.
+	 */
+	protected $endpoint;
+
+	/**
+	 * @param HasContacts $relatedEntity   related entity owning the contacts.
+	 * @inheritdoc
+	 */
+	public function __construct(HasContacts $relatedEntity)
+	{
+		parent::__construct();
+
+		$endpoint = Str::of(get_class($relatedEntity))
+			->afterLast('\\')
+			->lower()
+			->plural();
+
+		$this->entity     = Contact::class;
+		$this->collection = ContactCollection::class;
+
+		$this->endpoint = (string) $endpoint;
+		$this->relatedEntity = $relatedEntity;
+	}
+
+	/**
+	 * List all contacts.
+	 *
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-company-contacts
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-contacts
+	 */
+	public function index(array $query = []): Response
+	{
+		$response = $this->connection
+			->request("{$this->endpoint}/{$this->relatedEntity->id}/contacts")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Show a single contact by id.
+	 * (Duplicate of ConcatsApi::show())
+	 *
+	 * @param string $id     The contact id to retrieve.
+	 * @param array  $query  Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact
+	 */
+	public function show(string $id, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("contacts/{$id}")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Store (add) a link between a contact and a company.
+	 *
+	 * @param Contact $contact The contact entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-company-contact
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-individual-contact
+	 */
+	public function store(Contact $contact, array $query = []): Response
+	{
+		$response = $this->connection
+			->request("{$this->endpoint}/{$this->relatedEntity->id}/contacts/{$contact->id}")
+			->post($query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Update a contact link.
+	 *
+	 * @param Contact $contact	The contact entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-company-contact
+	 */
+	public function update(Contact $contact, array $query = []): Response
+	{
+		$body = $contact->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("{$this->endpoint}/{$this->relatedEntity->id}/contacts/{$contact->id}")
+			->put(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+	/**
+	 * Remove a contact link.
+	 *
+	 * @param int $id The contact id to be deleted.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/unlink-company-contact
+	 * @see https://api.sellsy.com/doc/v2/#operation/unlink-individual-contact
+	 */
+	public function destroy(int $id): Response
+	{
+		$response = $this->connection
+			->request("{$this->endpoint}/{$this->relatedEntity->id}/contacts/{$id}")
+			->delete();
+
+		return $this->prepareResponse($response);
+	}
+
+
+}

--- a/src/Api/EntityFavouriteFiltersApi.php
+++ b/src/Api/EntityFavouriteFiltersApi.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\FavouriteFilterCollection;
+use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Api\Contracts\HasFavouriteFiltersApi;
+use Bluerock\Sellsy\Entities\FavouriteFilter;
+use Illuminate\Support\Str;
+
+/**
+ * The API client for the favourite filters management of different entity type.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ */
+class EntityFavouriteFiltersApi extends AbstractApi
+{
+	use Concerns\CanManageFavouriteFiltersApi;
+
+	/**
+	 * @var string The related entity base endpoint.
+	 */
+	protected $endpoint;
+
+	/**
+	 * @param HasFavouriteFiltersApi $relatedApi   related entity owning the custom fields.
+	 * @inheritdoc
+	 */
+	public function __construct(HasFavouriteFiltersApi $relatedApi)
+	{
+		parent::__construct();
+
+		$endpoint = Str::of(get_class($relatedApi))
+			->afterLast('\\')
+			->replaceLast('Api', '')
+			->lower()
+			->plural();
+		$this->endpoint = (string) $endpoint;
+echo "{$this->endpoint}/favourite-filters\n";
+
+		$this->entity     = FavouriteFilter::class;
+		$this->collection = FavouriteFilterCollection::class;
+	}
+
+	/**
+	 * List all favourite filters.
+	 *
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-company-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-opportunity-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-estimate-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-invoice-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-order-favourite-filters
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-credit-note-favourite-filters
+	 */
+	public function index(array $query = []): Response
+	{
+		$response = $this->connection
+			->request("{$this->endpoint}/favourite-filters")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+}

--- a/src/Api/EntityFavouriteFiltersApi.php
+++ b/src/Api/EntityFavouriteFiltersApi.php
@@ -39,7 +39,6 @@ class EntityFavouriteFiltersApi extends AbstractApi
 			->lower()
 			->plural();
 		$this->endpoint = (string) $endpoint;
-echo "{$this->endpoint}/favourite-filters\n";
 
 		$this->entity     = FavouriteFilter::class;
 		$this->collection = FavouriteFilterCollection::class;

--- a/src/Api/IndividualsApi.php
+++ b/src/Api/IndividualsApi.php
@@ -15,8 +15,11 @@ use Bluerock\Sellsy\Core\Response;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Individuals
  */
-class IndividualsApi extends AbstractApi
+class IndividualsApi extends AbstractApi implements Contracts\HasContactsApi, Contracts\HasFavouriteFiltersApi
 {
+	use Concerns\CanManageContactsApi,
+		Concerns\CanManageFavouriteFiltersApi;
+
     /**
      * @inheritdoc
      */

--- a/src/Api/InvoicesApi.php
+++ b/src/Api/InvoicesApi.php
@@ -15,8 +15,10 @@ use Bluerock\Sellsy\Core\Response;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Invoices
  */
-class InvoicesApi extends AbstractApi
+class InvoicesApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi
 {
+	use Concerns\CanManageFavouriteFiltersApi;
+
     /**
      * @inheritdoc
      */

--- a/src/Collections/FavouriteFilterCollection.php
+++ b/src/Collections/FavouriteFilterCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Collections;
+
+use Bluerock\Sellsy\Entities\FavouriteFilter;
+use Bluerock\Sellsy\Contracts\EntityCollectionContract;
+use Spatie\DataTransferObject\DataTransferObjectCollection;
+
+/**
+ * The favourite filters collection.
+ *
+ * @package bluerock/sellsy-client
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.0
+ * @access public
+ *
+ * @method \Bluerock\Sellsy\Entities\FavouriteFilter current
+ */
+class FavouriteFilterCollection extends DataTransferObjectCollection implements EntityCollectionContract
+{
+	public static function create(array $data): FavouriteFilterCollection
+	{
+		return new static(FavouriteFilter::arrayOf($data));
+	}
+}

--- a/src/Core/Response.php
+++ b/src/Core/Response.php
@@ -51,7 +51,7 @@ class Response
         $this->resp    = $resp;
         $this->related = $related;
 
-        $this->body = new Fluent($this->json());
+        $this->body = new Fluent($this->json() ?? []);
     }
 
     /**

--- a/src/Entities/Client.php
+++ b/src/Entities/Client.php
@@ -16,14 +16,15 @@ use Bluerock\Sellsy\Entities\Contracts;
  * @version 1.1
  * @access public
  */
-abstract class Client extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields
+abstract class Client extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields, Contracts\HasContacts
 {
     use Attributes\Acl,
         Attributes\Statistics,
         Attributes\Addresses,
         Attributes\ContactInfos,
         Attributes\SmartTags,
-        Concerns\CanManageCustomFields;
+		Concerns\CanManageContacts,
+		Concerns\CanManageCustomFields;
 
     /**
      * <READONLY> Client ID from Sellsy.

--- a/src/Entities/Concerns/CanManageContacts.php
+++ b/src/Entities/Concerns/CanManageContacts.php
@@ -11,15 +11,15 @@ use Bluerock\Sellsy\Api;
  * @version 1.2.4
  * @access public
  */
-trait CanManageCustomFields
+trait CanManageContacts
 {
 	/**
-	 * Give the associated custom fields
+	 * Give the associated contacts API
 	 *
-	 * @return Api\EntityCustomFieldsApi
+	 * @return Api\EntityContactsApi
 	 */
-	public function customFields(): Api\EntityCustomFieldsApi
+	public function contacts(): Api\EntityContactsApi
 	{
-		return new Api\EntityCustomFieldsApi($this);
+		return new Api\EntityContactsApi($this);
 	}
 }

--- a/src/Entities/Contact.php
+++ b/src/Entities/Contact.php
@@ -21,7 +21,8 @@ class Contact extends Entity implements Contracts\HasAddresses, Contracts\HasCus
     use Attributes\Acl,
         Attributes\Addresses,
         Attributes\ContactInfos,
-        Attributes\SmartTags;
+        Attributes\SmartTags,
+		Concerns\CanManageCustomFields;
 
     /**
      * <READONLY> Contact ID from Sellsy.

--- a/src/Entities/Contracts/HasContacts.php
+++ b/src/Entities/Contracts/HasContacts.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Contracts;
+
+/**
+ * The contacts contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+interface HasContacts
+{
+}

--- a/src/Entities/FavouriteFilter.php
+++ b/src/Entities/FavouriteFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities;
+
+use Bluerock\Sellsy\Api;
+use Bluerock\Sellsy\Entities\Entity;
+
+/**
+ * The FavouriteFilter Entity.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.0
+ * @access public
+ */
+class FavouriteFilter extends Entity
+{
+    /**
+     * <READONLY> Favourite filter ID from Sellsy.
+     */
+    public ?int $id;
+
+    /**
+     * Favourite filter name.
+	 * IMPORTANT: type in the official doc, which indicates 'type' as the name of that key.
+	 * But the api returns 'name', so we stick at it
+     */
+    public ?string $name;
+
+}


### PR DESCRIPTION
Hello,

a new PR to manage contacts in entities and fetch custom filters id (to use them in `search()` functions)


**Add favourite filters management**
(Fetch filters that can be use in `search()` with key `favourite_filter`)
Added in contacts/individuals/companies API, with a new trait `Concerns\CanManageFavouriteFiltersApi` and a new contract interface `Contracts\HasFavouriteFiltersApi`
```php
$contactApi = new \Bluerock\Sellsy\Api\ContactsApi();
$filters = $contactApi->favouriteFilters()->index();
foreach($filters->entities() as $filter) {
	print_r($filter->toArray());
}
```

**Add an entity contacts management (add / remove a contact linked to an entity)**
Same thing, for contacts management
```php
$contactApi = new \Bluerock\Sellsy\Api\ContactsApi();
$contactEntity = $contactApi->show(12345)->entity();

$companyApi = new \Bluerock\Sellsy\Api\CompaniesApi();
$companyEntity = $companyApi->show(67890)->entity();

$companyEntity->contacts()->store($contactEntity);
$companyEntity->contacts()->destroy($contactId);
```


And a little FIX on Response, when 'null' is returned from the API (the code tried to do a foreach on it)
