### PR TITLE
Pr multi accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ $config->set('client_id', 'f48f0fgm-2703-5689-2005-27403b5adb8d')
 
 Learn more about Sellsy API v2 credentials on the [official documentation](https://api.sellsy.com/doc/v2/#section/Authentication).
 
+
+### Connect to multiple Sellsy accounts
+<a name="usage_auth_multi_account"></a>
+
+You can connect to many Sellsy accounts at the same time. You just need to configure each instance,
+then switch to one or another with `Config::switchInstance()` (returns a `Config` object for that specific account)
+ 
+```php
+// Configure the first Sellsy account
+Bluerock\Sellsy\Core\Config::switchInstance('first-sellsy')
+    ->set('client_id', 'id-1')
+    ->set('client_secret', 'secret1');
+
+// Configure another one
+Bluerock\Sellsy\Core\Config::switchInstance('other-sellsy')
+    ->set('client_id', 'id-2')
+    ->set('client_secret', 'secret2');
+
+// From now, each request is on the 'other-sellsy' account
+// ...
+
+// To switch back to the first account
+Bluerock\Sellsy\Core\Config::switchInstance('first-sellsy');
+```
+
+
 ## Querying the API
 <a name="usage_query"></a>
 

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -2,6 +2,7 @@
 
 namespace Bluerock\Sellsy\Core;
 
+use Bluerock\Sellsy\Exceptions\ApiClientErrorException;
 use Illuminate\Support\Arr;
 
 /**
@@ -15,25 +16,48 @@ use Illuminate\Support\Arr;
 class Config
 {
     /**
-     * The singleton instance.
+     * The singleton instances (one instance by Sellsy account)
      *
-     * @var Config
+     * @var Config[]
      */
-    protected static $_instance = null;
+    protected static $_instance = [];
+
+	/**
+	 * The current Sellsy account instance name
+	 * @var string
+	 */
+	protected static $_instance_name = '';
+
 
     /**
-     * Get the instance.
+     * Get the instance for the current Sellsy account. To change of context (if you have multiple Sellsy accounts
+	 * at the same time), use switchInstance() to switch to another one.
+	 * @param string $sellsy_account	An identifier for your Sellsy account. Empty if you have only one account
      *
      * @return Config
      */
     public static function getInstance()
     {
-        if (!static::$_instance) {
-            static::$_instance = new static;
+        if (!isset(static::$_instance[static::$_instance_name])) {
+            static::$_instance[static::$_instance_name] = new static;
         }
-
-        return static::$_instance;
+        return static::$_instance[static::$_instance_name];
     }
+
+
+	/**
+	 * Only use if you have multiple Sellsy accounts opened at the same time. Switch to a new instance, identified
+	 * by an arbitrary name you give. Every web request made after this operation will be on the new active instance
+	 * @param string $sellsy_account	An identifier for your Sellsy account. Empty string to switch back to
+	 *                               	the main account (the first one)
+	 *
+	 * @return Config
+	 */
+	public static function switchInstance(string $sellsy_account = '')
+	{
+		static::$_instance_name = $sellsy_account;
+	}
+
 
     /**
      * Private constructor for the singleton.

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -56,6 +56,7 @@ class Config
 	public static function switchInstance(string $sellsy_account = '')
 	{
 		static::$_instance_name = $sellsy_account;
+		return static::getInstance();
 	}
 
 

--- a/src/Core/Connection.php
+++ b/src/Core/Connection.php
@@ -22,12 +22,6 @@ class Connection
      */
     protected static $_instance = null;
 
-    /**
-     * The config instance.
-     *
-     * @var Config
-     */
-    protected $config = null;
 
     /**
      * Get the instance.
@@ -48,7 +42,6 @@ class Connection
      */
     private function __construct()
     {
-        $this->config = Config::getInstance();
     }
     
     /**
@@ -75,7 +68,7 @@ class Connection
      */
     public function request(string $endpoint)
     {
-        $endpoint = sprintf('%s/%s', trim($this->config->get('url'), '/'), ltrim($endpoint, '/'));
+        $endpoint = sprintf('%s/%s', trim(Config::getInstance()->get('url'), '/'), ltrim($endpoint, '/'));
 
         return Request::make($endpoint)
                     ->withToken($this->getToken())
@@ -92,7 +85,7 @@ class Connection
      */
     protected function hasValidToken()
     {
-        return $this->config->get('authentication.token') && time() < $this->config->get('authentication.expires_at');
+        return Config::getInstance()->get('authentication.token') && time() < Config::getInstance()->get('authentication.expires_at');
     }
     
     /**
@@ -103,19 +96,20 @@ class Connection
      */
     protected function getToken()
     {
+		$config = Config::getInstance();
         if ($this->hasValidToken()) {
-            return $this->config->get('authentication.token');
+            return $config->get('authentication.token');
         }
 
         $auth = new Authentication();
 
         $token = $auth->getToken(
-            $this->config->get('client_id'),
-            $this->config->get('client_secret'),
+            $config->get('client_id'),
+            $config->get('client_secret'),
         );
 
-        $this->config->set('authentication.token', $token['access_token']);
-        $this->config->set('authentication.expires_at', time() + $token['expires_in']);
+        $config->set('authentication.token', $token['access_token']);
+        $config->set('authentication.expires_at', time() + $token['expires_in']);
 
         return $token['access_token'];
     }


### PR DESCRIPTION
For now, the library is made to manage only one Sellsy account, defined in a global 'singleton' config.
But if you have a second connection (for example -- which was my case -- if you want to duplicate data from a Sellsy to another), you are stuck because of that singleton.

Here is a PR to allow switching context between the different accounts. I mainly:

- added a context in `Config` (instead of having a singleton, we now have an array of `Config` singletons, one for each context)
- added `Config::switchInstance(string name)` to change the context and use the new config params
- altered `Connection` to call `Config::getInstance()` instead of `$this->config` (which is not a problem, as you made a singleton, it is fast enough). That way we always query the active context

Usage example:
```php
\Bluerock\Sellsy\Core\Config::getInstance()
	->set('client_id',	'id-1')
	->set('client_secret',	'secret1');

\Bluerock\Sellsy\Core\Config::switchInstance('other-sellsy')
	->set('client_id',	'id-2')
	->set('client_secret',	'secret2');

// We are now requesting the 'other-sellsy' account

// We want to request the first-one
\Bluerock\Sellsy\Core\Config::switchInstance();
```

We can even specify a name for the first-one too if we wan't (facultative), by calling the switchInstance at the begining:
```php
\Bluerock\Sellsy\Core\Config::switchInstance('first-sellsy')
	->set('client_id',	'id-1')
	->set('client_secret',	'secret1');

\Bluerock\Sellsy\Core\Config::switchInstance('other-sellsy')
	->set('client_id',	'id-2')
	->set('client_secret',	'secret2');

// We are now requesting the 'other-sellsy' account

// We want to request the first-one
\Bluerock\Sellsy\Core\Config::switchInstance('first-sellsy');
```