### PR TITLE
Add smart tags management, the same way than custom fields

### DIFF
--- a/src/Api/EntitySmartTagsApi.php
+++ b/src/Api/EntitySmartTagsApi.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\SmartTagCollection;
+use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Entities\Contracts\HasSmartTags;
+use Bluerock\Sellsy\Entities\SmartTag;
+use Illuminate\Support\Str;
+
+/**
+ * The API client for the smarts tags management in an entity.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ */
+class EntitySmartTagsApi extends AbstractApi
+{
+	/**
+	 * @var HasSmartTags The related entity owning the smart tags.
+	 */
+	protected $relatedEntity;
+
+	/**
+	 * @var string The related entity base endpoint.
+	 */
+	protected $endpoint;
+
+	/**
+	 * @param HasSmartTags $relatedEntity   related entity owning the smart tags.
+	 * @inheritdoc
+	 */
+	public function __construct(HasSmartTags $relatedEntity)
+	{
+		parent::__construct();
+
+		$endpoint = Str::of(get_class($relatedEntity))
+			->afterLast('\\')
+			->lower()
+			->plural();
+		$this->entity     = SmartTag::class;
+		$this->collection = SmartTagCollection::class;
+
+		$this->endpoint = (string) $endpoint;
+		$this->relatedEntity = $relatedEntity;
+	}
+
+	/**
+	 * List all smart tags.
+	 *
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-invoice-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-estimate-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-opportunity-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-credit-note-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-company-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-contact-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-individual-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-order-smart-tags
+	 */
+	public function index(array $query = []): Response
+	{
+		$response = $this->connection
+			->request("{$this->endpoint}/{$this->relatedEntity->id}/smart-tags")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+
+	/**
+	 * Store (add) a smart tag to the entity.
+	 *
+	 * @param SmartTag $smartTag	The smart tag to assign.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-opportunity-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-estimate-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-invoice-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-credit-note-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-company-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-contact-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-individual-smart-tags
+	 * @see https://api.sellsy.com/doc/v2/#operation/link-order-smart-tags
+	 */
+	public function store(SmartTag $smartTag, array $query = []): Response
+	{
+		$body = $smartTag->toArray();
+		$response = $this->connection
+			->request($this->appendQuery("{$this->endpoint}/{$this->relatedEntity->id}/smart-tags", $query))
+			->post([$body]);
+
+		return $this->prepareResponse($response);
+	}
+
+}

--- a/src/Collections/SmartTagCollection.php
+++ b/src/Collections/SmartTagCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bluerock\Sellsy\Collections;
+
+use Bluerock\Sellsy\Entities\SmartTag;
+use Bluerock\Sellsy\Contracts\EntityCollectionContract;
+use Spatie\DataTransferObject\DataTransferObjectCollection;
+
+/**
+ * The smart tags collection.
+ *
+ * @package bluerock/sellsy-client
+ * @author Thomas <thomas@bluerocktel.com>
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.0
+ * @access public
+ *
+ * @method \Bluerock\Sellsy\Entities\SmartTag current
+ */
+class SmartTagCollection extends DataTransferObjectCollection implements EntityCollectionContract
+{
+	public static function create(array $data): SmartTagCollection
+	{
+		return new static(SmartTag::arrayOf($data));
+	}
+}

--- a/src/Entities/Client.php
+++ b/src/Entities/Client.php
@@ -16,7 +16,11 @@ use Bluerock\Sellsy\Entities\Contracts;
  * @version 1.1
  * @access public
  */
-abstract class Client extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields, Contracts\HasContacts
+abstract class Client extends Entity
+	implements  Contracts\HasAddresses,
+				Contracts\HasCustomFields,
+				Contracts\HasContacts,
+				Contracts\HasSmartTags
 {
     use Attributes\Acl,
         Attributes\Statistics,
@@ -24,7 +28,8 @@ abstract class Client extends Entity implements Contracts\HasAddresses, Contract
         Attributes\ContactInfos,
         Attributes\SmartTags,
 		Concerns\CanManageContacts,
-		Concerns\CanManageCustomFields;
+		Concerns\CanManageCustomFields,
+		Concerns\CanManageSmartTags;
 
     /**
      * <READONLY> Client ID from Sellsy.

--- a/src/Entities/Concerns/CanManageSmartTags.php
+++ b/src/Entities/Concerns/CanManageSmartTags.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access public
+ */
+trait CanManageSmartTags
+{
+	/**
+	 * Give the associated smart tags
+	 *
+	 * @return Api\EntitySmartTagsApi
+	 */
+	public function smartTags(): Api\EntitySmartTagsApi
+	{
+		return new Api\EntitySmartTagsApi($this);
+	}
+}

--- a/src/Entities/Contact.php
+++ b/src/Entities/Contact.php
@@ -16,13 +16,14 @@ use Bluerock\Sellsy\Entities\Contracts;
  * @version 1.0
  * @access public
  */
-class Contact extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields
+class Contact extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields, Contracts\HasSmartTags
 {
     use Attributes\Acl,
         Attributes\Addresses,
         Attributes\ContactInfos,
         Attributes\SmartTags,
-		Concerns\CanManageCustomFields;
+		Concerns\CanManageCustomFields,
+		Concerns\CanManageSmartTags;
 
     /**
      * <READONLY> Contact ID from Sellsy.

--- a/src/Entities/Contracts/HasSmartTags.php
+++ b/src/Entities/Contracts/HasSmartTags.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Contracts;
+
+/**
+ * The smart tags contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+interface HasSmartTags
+{
+}

--- a/src/Entities/Invoice.php
+++ b/src/Entities/Invoice.php
@@ -14,9 +14,12 @@ use Bluerock\Sellsy\Entities\InvoiceAmounts;
  * @version 1.2.3
  * @access public
  */
-class Invoice extends Entity implements Contracts\HasCustomFields
+class Invoice extends Entity implements Contracts\HasCustomFields, Contracts\HasSmartTags
 {
-	use Concerns\CanManageCustomFields;
+	use Attributes\SmartTags,
+		Concerns\CanManageCustomFields,
+		Concerns\CanManageSmartTags;
+
 
     /**
      * <READONLY> Invoice ID from Sellsy.


### PR DESCRIPTION
Add smart tags management, to fetch / add tags to entities, the same way we did for custom fields.

Some usage examples:
```php
# Get smart tags associated to an entity:
$clientEntity->smartTags()->index()->entities();
$invoiceEntity->smartTags()->index()->entities();

# Add a smart tag to an entity, and get the resulting created tag:
$response = $clientEntity->smartTags()->store(
	new \Bluerock\Sellsy\Entities\SmartTag([
		'value' => 'testTag'
	])
);
print_r($response->entities());
```