### PR TITLE
Invoices discounts are an array, not an int

### DIFF
--- a/src/Entities/Invoice.php
+++ b/src/Entities/Invoice.php
@@ -46,7 +46,7 @@ class Invoice extends Entity implements Contracts\HasCustomFields
 
     public ?array $taxes;
 
-    public ?int $discount;
+    public ?array $discount;
 
     public ?int $fiscal_year_id;
 


### PR DESCRIPTION
I found a little bug on discounted invoices. The discount is an array, not an int.
The official ref: https://api.sellsy.com/doc/v2/#operation/get-invoice

And when I fetch an invoice, I have for example:
```php
[discount] => Array
(
    [percent] => 0.11
    [amount] => 8.36
    [type] => amount
)
```

I propose to change the `Invoice.discount` type fron `int` to `array` (the current PR)

Another option would be to create a new `InvoiceDiscount` class, but as `Invoices.tax` is also an array, this is not the same behavior.

Please let me know if it is OK like this or if you prefers a new class like: 
```php
<?php
namespace Bluerock\Sellsy\Entities;
class InvoiceDiscount extends Entity
{
    public string $percent                       = "0";
    public string $amount                        = "0";
    public ?string $type;
}
```