### PR TITLE
Add credit-notes support

### DIFF
--- a/src/Api/Concerns/CanManageCreditNotesApi.php
+++ b/src/Api/Concerns/CanManageCreditNotesApi.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+trait CanManageCreditNotesApi
+{
+	/**
+	 * Give the credit notes
+	 *
+	 * @return Api\EntityCreditNotesApi
+	 */
+	public function creditNotes(): Api\EntityCreditNotesApi
+	{
+		return new Api\EntityCreditNotesApi($this);
+	}
+}

--- a/src/Api/Contracts/HasCreditNotesApi.php
+++ b/src/Api/Contracts/HasCreditNotesApi.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Contracts;
+
+/**
+ * The invoices credit-notes API contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+interface HasCreditNotesApi
+{
+}

--- a/src/Api/CreditNotesApi.php
+++ b/src/Api/CreditNotesApi.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\CreditNoteCollection;
+use Bluerock\Sellsy\Entities\Company;
+use Bluerock\Sellsy\Entities\CreditNote;
+use Bluerock\Sellsy\Core\Response;
+
+/**
+ * The API client for the `credit-notes` namespace.
+ *
+ * @package bluerock/sellsy-client
+ * @author Thomas <thomas@bluerocktel.com>
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ * @see https://api.sellsy.com/doc/v2/#tag/Invoices
+ */
+class CreditNotesApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi
+{
+	use Concerns\CanManageFavouriteFiltersApi;
+
+    /**
+     * @inheritdoc
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->entity     = CreditNote::class;
+        $this->collection = CreditNoteCollection::class;
+    }
+
+    /**
+     * List all credit-notes.
+     *
+     * @param array $query Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/get-credit-note
+     */
+    public function index(array $query = []): Response
+    {
+        $response = $this->connection
+                        ->request('credit-notes')
+                        ->get($query);
+
+        return $this->prepareResponse($response);
+    }
+
+    /**
+     * Show a single credit-note by id.
+     *
+     * @param string $id     The credit-note id to retrieve.
+     * @param array  $query  Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/get-credit-note
+     */
+    public function show(string $id, array $query = []): Response
+    {
+        $response = $this->connection
+                        ->request("credit-notes/{$id}")
+                        ->get($query);
+
+        return $this->prepareResponse($response);
+    }
+
+    /**
+     * Search for credit-notes using filters.
+     *
+     * @param array $query Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @seehttps://api.sellsy.com/doc/v2/#operation/search-credit-notes
+     */
+    public function search(array $filters = [], array $query = []): Response
+    {
+        $response = $this->connection
+                        ->request($this->appendQuery('credit-notes/search', $query))
+                        ->post(compact('filters'));
+
+        return $this->prepareResponse($response);
+    }
+
+
+	/**
+	 * Store (create) a credit note.
+	 *
+	 * @param CreditNote $creditNote The credit-note entity to store.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/create-credit-note
+	 */
+	public function store(CreditNote $creditNote, array $query = []): Response
+	{
+		$body = $creditNote->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request('credit-notes')
+			->post(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+
+
+	/**
+	 * Update an existing credit-note.
+	 *
+	 * @param CreditNote $creditNote The credit-note entity to update.
+	 * @param array   $query   Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/update-credit-note
+	 */
+	public function update(CreditNote $creditNote, array $query = []): Response
+	{
+		$body = $creditNote->except('id')
+			->except('owner')
+			->toArray();
+
+		$response = $this->connection
+			->request("credit-notes/{$creditNote->id}")
+			->put(array_filter($body) + $query);
+
+		return $this->prepareResponse($response);
+	}
+}

--- a/src/Api/EntityCreditNotesApi.php
+++ b/src/Api/EntityCreditNotesApi.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Bluerock\Sellsy\Collections\CreditNoteCollection;
+use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Entities\Contracts\HasCreditNotes;
+use Bluerock\Sellsy\Entities\CreditNote;
+use Illuminate\Support\Str;
+
+/**
+ * The API client for the credit-notes management in an entity.
+ * If you are looking for credit-notes declarations in Sellsy,
+ * see CreditNotesApi
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ */
+class EntityCreditNotesApi extends AbstractApi
+{
+	/**
+	 * @var HasCreditNotes The related entity owning the credit notes.
+	 */
+	protected $relatedEntity;
+
+	/**
+	 * @var string The related entity base endpoint.
+	 */
+	protected $endpoint;
+
+	/**
+	 * @param HasCreditNotes $relatedEntity   related entity owning the custom fields.
+	 * @inheritdoc
+	 */
+	public function __construct(HasCreditNotes $relatedEntity)
+	{
+		parent::__construct();
+
+		$endpoint = Str::of(get_class($relatedEntity))
+			->afterLast('\\')
+			->lower()
+			->plural();
+		$this->entity     = CreditNote::class;
+		$this->collection = CreditNoteCollection::class;
+
+		$this->endpoint = (string) $endpoint;
+		$this->relatedEntity = $relatedEntity;
+	}
+
+	/**
+	 * List all credit-notes.
+	 *
+	 * @param array $query Query parameters.
+	 *
+	 * @return \Bluerock\Sellsy\Core\Response
+	 * @see https://api.sellsy.com/doc/v2/#operation/get-invoice-credit-notes
+	 */
+	public function index(array $query = []): Response
+	{
+		$response = $this->connection
+			->request("{$this->endpoint}/{$this->relatedEntity->id}/credit-notes")
+			->get($query);
+
+		return $this->prepareResponse($response);
+	}
+
+}

--- a/src/Api/InvoicesApi.php
+++ b/src/Api/InvoicesApi.php
@@ -15,9 +15,11 @@ use Bluerock\Sellsy\Core\Response;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Invoices
  */
-class InvoicesApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi
+class InvoicesApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi, Contracts\HasCreditNotesApi
 {
-	use Concerns\CanManageFavouriteFiltersApi;
+	use Concerns\CanManageCreditNotesApi,
+		Concerns\CanManageFavouriteFiltersApi;
+
 
     /**
      * @inheritdoc

--- a/src/Collections/CreditNoteCollection.php
+++ b/src/Collections/CreditNoteCollection.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Collections;
+
+use Bluerock\Sellsy\Entities\CreditNote;
+
+
+/**
+ * The CreditNote Entity collection.
+ *
+ * @package bluerock/sellsy-client
+ * @author Thomas <thomas@bluerocktel.com>
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ *
+ * @method \Bluerock\Sellsy\Entities\CreditNote current
+ */
+class CreditNoteCollection extends InvoiceCollection
+{
+    public static function create(array $data): CreditNoteCollection
+    {
+        return new static(CreditNote::arrayOf($data));
+    }
+}

--- a/src/Collections/InvoiceCollection.php
+++ b/src/Collections/InvoiceCollection.php
@@ -11,6 +11,7 @@ use Spatie\DataTransferObject\DataTransferObjectCollection;
  *
  * @package bluerock/sellsy-client
  * @author Thomas <thomas@bluerocktel.com>
+ * @author Jérémie <jeremie@kiwik.com>
  * @version 1.2.3
  * @access public
  *

--- a/src/Entities/Concerns/CanManageCreditNotes.php
+++ b/src/Entities/Concerns/CanManageCreditNotes.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+trait CanManageCreditNotes
+{
+	/**
+	 * Give the credit notes
+	 *
+	 * @return Api\EntityCreditNotesApi
+	 */
+	public function creditNotes(): Api\EntityCreditNotesApi
+	{
+		return new Api\EntityCreditNotesApi($this);
+	}
+}

--- a/src/Entities/Contracts/HasCreditNotes.php
+++ b/src/Entities/Contracts/HasCreditNotes.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Contracts;
+
+/**
+ * The contacts contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.2.4
+ * @access  public
+ */
+interface HasCreditNotes
+{
+}

--- a/src/Entities/CreditNote.php
+++ b/src/Entities/CreditNote.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities;
+
+use Bluerock\Sellsy\Entities\Contracts;
+use Bluerock\Sellsy\Entities\Entity;
+use Bluerock\Sellsy\Entities\InvoiceAmounts;
+
+/**
+ * The CreditNote Entity.
+ *
+ * @package bluerock/sellsy-client
+ * @author Thomas <thomas@bluerocktel.com>
+ * @author Jérémie <jeremie@kiwik.com>
+ * @version 1.2.3
+ * @access public
+ */
+class CreditNote extends Invoice
+{
+
+}

--- a/src/Entities/Invoice.php
+++ b/src/Entities/Invoice.php
@@ -14,9 +14,10 @@ use Bluerock\Sellsy\Entities\InvoiceAmounts;
  * @version 1.2.3
  * @access public
  */
-class Invoice extends Entity implements Contracts\HasCustomFields, Contracts\HasSmartTags
+class Invoice extends Entity implements Contracts\HasCustomFields, Contracts\HasSmartTags, Contracts\HasCreditNotes
 {
 	use Attributes\SmartTags,
+		Concerns\CanManageCreditNotes,
 		Concerns\CanManageCustomFields,
 		Concerns\CanManageSmartTags;
 


### PR DESCRIPTION
hello,
here is a PR to add support for credit-notes, which are in fact... invoices.
I focused on "reading data", so some sub-options like 'associate/remove a credit-note to as invoice' are not done yet. (The account I use is for production purpose, so I don't want to mess-up the financial result of my company with tests, sorry :-/ )

I added a helper in invoices to fetch their credit-notes, the same way we did for custom fields:
``` php
$invoiceEntity->creditNotes()
```

Some examples:
```php
// List credit-notes:
$creditNotesApi = new \Bluerock\Sellsy\Api\CreditNotesApi();
$creditNotes = $creditNotesApi->index()->entities();
echo 'Credit-notes : ', print_r($creditNotes, true), PHP_EOL;

// Get credit-notes associated to an invoice:
$invoicesApi = new \Bluerock\Sellsy\Api\InvoicesApi();
$invoiceEntity = $invoicesApi->show(123456789)->entity();
$creditNotes = $invoiceEntity->creditNotes()->index()->entities();
echo 'Credit-notes linked to the invoice: ', print_r($creditNotes, true), PHP_EOL;
```