### PR TITLE
PR - Add 'comments' endpoints

### DIFF
--- a/src/Api/CommentsApi.php
+++ b/src/Api/CommentsApi.php
@@ -2,146 +2,144 @@
 
 namespace Bluerock\Sellsy\Api;
 
-use Bluerock\Sellsy\Entities\Company;
-use Bluerock\Sellsy\Collections\CompanyCollection;
+use Bluerock\Sellsy\Collections\CommentCollection;
 use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Entities\Comment;
 
 /**
- * The API client for the `companies` namespace.
+ * The API client for the `comments` namespace.
  *
  * @package bluerock/sellsy-client
- * @author Thomas <thomas@bluerocktel.com>
+ * @author Jérémie <jeremie@kiwik/com>
  * @version 1.2.3
  * @access public
- * @see https://api.sellsy.com/doc/v2/#tag/Companies
+ * @see https://api.sellsy.com/doc/v2/#tag/Comments
  */
-class CompaniesApi extends AbstractApi implements Contracts\HasContactsApi, Contracts\HasFavouriteFiltersApi, Contracts\HasCommentsApi
+class CommentsApi extends AbstractApi
 {
-	use Concerns\CanManageContactsApi,
-		Concerns\CanManageFavouriteFiltersApi,
-		Concerns\CanManageCommentsApi;
-
-    /**
+	/**
      * @inheritdoc
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->entity     = Company::class;
-        $this->collection = CompanyCollection::class;
+        $this->entity     = Comment::class;
+        $this->collection = CommentCollection::class;
     }
 
     /**
-     * List all companies.
+     * List all comments.
      *
      * @param array $query Query parameters.
      *
      * @return \Bluerock\Sellsy\Core\Response
-     * @see https://api.sellsy.com/doc/v2/#operation/get-companies
+     * @see https://api.sellsy.com/doc/v2/#operation/get-comments
      */
     public function index(array $query = []): Response
     {
         $response = $this->connection
-                        ->request('companies')
+                        ->request('comments')
                         ->get($query);
 
         return $this->prepareResponse($response);
     }
 
     /**
-     * Show a single company by id.
+     * Show a single comment by id.
      *
-     * @param string $id     The company id to retrieve.
+     * @param string $id     The comment id to retrieve.
      * @param array  $query  Query parameters.
      *
      * @return \Bluerock\Sellsy\Core\Response
-     * @see https://api.sellsy.com/doc/v2/#operation/get-company
+     * @see https://api.sellsy.com/doc/v2/#operation/get-comment
      */
     public function show(string $id, array $query = []): Response
     {
         $response = $this->connection
-                        ->request("companies/{$id}")
+                        ->request("comments/{$id}")
                         ->get($query);
 
         return $this->prepareResponse($response);
     }
 
     /**
-     * Store (create) an company.
+     * Store (create) an comment.
      *
-     * @param Company $company The company entity to store.
+     * @param Comment $comment The comment entity to store.
      * @param array   $query   Query parameters.
      *
      * @return \Bluerock\Sellsy\Core\Response
-     * @see https://api.sellsy.com/doc/v2/#operation/create-company
+     * @see https://api.sellsy.com/doc/v2/#operation/create-comment
      */
-    public function store(Company $company, array $query = []): Response
+    public function store(Comment $comment, array $query = []): Response
     {
-        $body = $company->except('id')
+        $body = $comment->except('id')
                         ->except('owner')
                         ->toArray();
 
         $response = $this->connection
-                        ->request('companies')
+                        ->request('comments')
                         ->post(array_filter($body) + $query);
 
         return $this->prepareResponse($response);
     }
 
     /**
-     * Update an existing company.
+     * Update an existing comment.
      *
-     * @param Company $company The company entity to store.
+     * @param Comment $comment The comment entity to store.
      * @param array   $query   Query parameters.
      *
      * @return \Bluerock\Sellsy\Core\Response
-     * @see https://api.sellsy.com/doc/v2/#operation/update-company
+     * @see https://api.sellsy.com/doc/v2/#operation/update-comment
      */
-    public function update(Company $company, array $query = []): Response
+    public function update(Comment $comment, array $query = []): Response
     {
-        $body = $company->except('id')
+        $body = $comment->except('id')
                         ->except('owner')
                         ->toArray();
 
         $response = $this->connection
-                        ->request("companies/{$company->id}")
+                        ->request("comments/{$comment->id}")
                         ->put(array_filter($body) + $query);
 
         return $this->prepareResponse($response);
     }
 
     /**
-     * Delete an existing company.
+     * Delete an existing comment.
      *
-     * @param int $id The company id to be deleted.
+     * @param int $id The comment id to be deleted.
      *
      * @return \Bluerock\Sellsy\Core\Response
-     * @see https://api.sellsy.com/doc/v2/#operation/delete-company
+     * @see https://api.sellsy.com/doc/v2/#operation/delete-comment
      */
     public function destroy(int $id): Response
     {
         $response = $this->connection
-                        ->request("companies/{$id}")
+                        ->request("comments/{$id}")
                         ->delete();
 
         return $this->prepareResponse($response);
     }
 
     /**
-     * Search for companies using filters.
+     * Search comments with some filters.
      *
-     * @param array $query Query parameters.
+     * @param array $query    Query parameters.
+     * @param array $filters  Filters to use.
      *
      * @return \Bluerock\Sellsy\Core\Response
-     * @see https://api.sellsy.com/doc/v2/#operation/search-companies
+     * @see https://api.sellsy.com/doc/v2/#operation/search-comments
      */
-    public function search(array $filters = [], array $query = []): Response
+    public function search(array $query = [], array $filters = []): Response
     {
         $response = $this->connection
-                        ->request($this->appendQuery('companies/search', $query))
+                        ->request($this->appendQuery('comments/search', $query))
                         ->post(compact('filters'));
 
         return $this->prepareResponse($response);
     }
+
 }

--- a/src/Api/Concerns/CanManageCommentsApi.php
+++ b/src/Api/Concerns/CanManageCommentsApi.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access public
+ */
+trait CanManageCommentsApi
+{
+	/**
+	 * Give the comments API
+	 *
+	 * @return Api\CommentsApi
+	 */
+	public function comments(): Api\EntityCommentsApi
+	{
+		return new Api\EntityCommentsApi($this);
+	}
+}

--- a/src/Api/ContactsApi.php
+++ b/src/Api/ContactsApi.php
@@ -15,9 +15,10 @@ use Bluerock\Sellsy\Collections\ContactCollection;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Contacts
  */
-class ContactsApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi
+class ContactsApi extends AbstractApi implements Contracts\HasFavouriteFiltersApi, Contracts\HasCommentsApi
 {
-	use Concerns\CanManageFavouriteFiltersApi;
+	use Concerns\CanManageFavouriteFiltersApi,
+		Concerns\CanManageCommentsApi;
 
     /**
      * @inheritdoc

--- a/src/Api/Contracts/HasCommentsApi.php
+++ b/src/Api/Contracts/HasCommentsApi.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bluerock\Sellsy\Api\Contracts;
+
+/**
+ * The comments API contract.
+ *
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author  Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access  public
+ */
+interface HasCommentsApi
+{
+}

--- a/src/Api/EntityCommentsApi.php
+++ b/src/Api/EntityCommentsApi.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Bluerock\Sellsy\Api;
+
+use Illuminate\Support\Str;
+use Bluerock\Sellsy\Core\Response;
+use Bluerock\Sellsy\Collections\CommentCollection;
+use Bluerock\Sellsy\Entities\Comment;
+use Bluerock\Sellsy\Entities\Contracts\HasAddresses;
+
+
+/**
+ * The API client for the `addresses` namespace.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ */
+class EntityCommentsApi extends AbstractApi
+{
+	/**
+	 * @var HasAddresses The related entity owning the comments.
+	 */
+	protected $relatedEntity;
+
+	/**
+	 * @var string The related entity base endpoint.
+	 */
+	protected $endpoint;
+
+    /**
+	 * @param HasAddresses $relatedEntity   related entity owning the address.
+     * @inheritdoc
+     */
+    public function __construct(HasAddresses $relatedEntity)
+    {
+        parent::__construct();
+
+        $endpoint = Str::of(get_class($relatedEntity))
+            ->afterLast('\\')
+            ->lower()
+            ->plural();
+
+        $this->entity     = Comment::class;
+        $this->collection = CommentCollection::class;
+
+        $this->endpoint = (string) $endpoint;
+        $this->relatedEntity = $relatedEntity;
+    }
+
+
+    /**
+     * List all comments of the related entity.
+     * (Do a search call with the related entity id as filter)
+     *
+     * @param array $query Query parameters.
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/get-comments
+     */
+    public function index(array $query = []): Response
+    {
+        return $this->search($query);
+    }
+
+
+    /**
+     * Search comments associated to the related entity with some filters.
+     *
+     * @param array $query    Query parameters.
+     * @param array $filters  Filters to use (will be merged with the filter for the related entity).
+     *
+     * @return \Bluerock\Sellsy\Core\Response
+     * @see https://api.sellsy.com/doc/v2/#operation/search-comments
+     */
+    public function search(array $query = [], array $filters = []): Response
+    {
+        $filters[$this->endpoint] = [ $this->relatedEntity->id ];
+
+        $response = $this->connection
+            ->request($this->appendQuery('comments/search', $query))
+            ->post(compact('filters'));
+
+        return $this->prepareResponse($response);
+    }
+
+}

--- a/src/Api/IndividualsApi.php
+++ b/src/Api/IndividualsApi.php
@@ -15,10 +15,11 @@ use Bluerock\Sellsy\Core\Response;
  * @access public
  * @see https://api.sellsy.com/doc/v2/#tag/Individuals
  */
-class IndividualsApi extends AbstractApi implements Contracts\HasContactsApi, Contracts\HasFavouriteFiltersApi
+class IndividualsApi extends AbstractApi implements Contracts\HasContactsApi, Contracts\HasFavouriteFiltersApi, Contracts\HasCommentsApi
 {
 	use Concerns\CanManageContactsApi,
-		Concerns\CanManageFavouriteFiltersApi;
+		Concerns\CanManageFavouriteFiltersApi,
+		Concerns\CanManageCommentsApi;
 
     /**
      * @inheritdoc

--- a/src/Collections/CommentCollection.php
+++ b/src/Collections/CommentCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bluerock\Sellsy\Collections;
+
+use Bluerock\Sellsy\Entities\Comment;
+use Bluerock\Sellsy\Contracts\EntityCollectionContract;
+use Spatie\DataTransferObject\DataTransferObjectCollection;
+
+/**
+ * The Comment Entity collection.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access public
+ *
+ * @method \Bluerock\Sellsy\Entities\Comment current
+ */
+class CommentCollection extends DataTransferObjectCollection implements EntityCollectionContract
+{
+    public static function create(array $data): CommentCollection
+    {
+        return new static(Comment::arrayOf($data));
+    }
+}

--- a/src/Entities/Client.php
+++ b/src/Entities/Client.php
@@ -20,7 +20,8 @@ abstract class Client extends Entity
 	implements  Contracts\HasAddresses,
 				Contracts\HasCustomFields,
 				Contracts\HasContacts,
-				Contracts\HasSmartTags
+				Contracts\HasSmartTags,
+				Contracts\HasComments
 {
     use Attributes\Acl,
         Attributes\Statistics,
@@ -29,7 +30,8 @@ abstract class Client extends Entity
         Attributes\SmartTags,
 		Concerns\CanManageContacts,
 		Concerns\CanManageCustomFields,
-		Concerns\CanManageSmartTags;
+		Concerns\CanManageSmartTags,
+        Concerns\CanManageComments;
 
     /**
      * <READONLY> Client ID from Sellsy.

--- a/src/Entities/Comment.php
+++ b/src/Entities/Comment.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities;
+
+use Bluerock\Sellsy\Entities\Entity;
+
+/**
+ * The Comment Entity.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access public
+ */
+class Comment extends Entity
+{
+    /**
+     * <READONLY> Comment ID from Sellsy.
+     */
+    public ?int $id;
+
+    /**
+     * Comment description.
+     */
+    public ?string $description;
+
+    /**
+     * <READONLY> Comment last update date from Sellsy.
+     */
+    public ?string $updated;
+
+    /**
+     * <READONLY> Comment create date from Sellsy.
+     */
+    public ?string $created;
+
+    /**
+     * <READONLY> Contact owner from Sellsy.
+     */
+    public ?array $owner;
+
+    /**
+     * Comment parent ID.
+     */
+    public ?int $parent_id;
+
+    /**
+     * Associated company ID from Sellsy.
+     */
+    public ?int $company_id;
+
+    /**
+     * Associated individual ID from Sellsy.
+     */
+    public ?int $individual_id;
+
+    /**
+     * Associated contact ID from Sellsy.
+     */
+    public ?int $contact_id;
+
+    /**
+     * Associated timetracking from Sellsy.
+     */
+    public ?Timetracking $timetracking;
+
+
+}

--- a/src/Entities/Concerns/CanManageComments.php
+++ b/src/Entities/Concerns/CanManageComments.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Concerns;
+
+use Bluerock\Sellsy\Api;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author  Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access public
+ */
+trait CanManageComments
+{
+	/**
+	 * Give the associated comments API
+	 *
+	 * @return Api\EntityCommentsApi
+	 */
+	public function comments(): Api\EntityCommentsApi
+	{
+		return new Api\EntityCommentsApi($this);
+	}
+}

--- a/src/Entities/Contact.php
+++ b/src/Entities/Contact.php
@@ -16,14 +16,15 @@ use Bluerock\Sellsy\Entities\Contracts;
  * @version 1.0
  * @access public
  */
-class Contact extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields, Contracts\HasSmartTags
+class Contact extends Entity implements Contracts\HasAddresses, Contracts\HasCustomFields, Contracts\HasSmartTags, Contracts\HasComments
 {
     use Attributes\Acl,
         Attributes\Addresses,
         Attributes\ContactInfos,
         Attributes\SmartTags,
 		Concerns\CanManageCustomFields,
-		Concerns\CanManageSmartTags;
+		Concerns\CanManageSmartTags,
+        Concerns\CanManageComments;
 
     /**
      * <READONLY> Contact ID from Sellsy.

--- a/src/Entities/Contracts/HasComments.php
+++ b/src/Entities/Contracts/HasComments.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities\Contracts;
+
+/**
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access public
+ */
+interface HasComments
+{
+}

--- a/src/Entities/Timetracking.php
+++ b/src/Entities/Timetracking.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bluerock\Sellsy\Entities;
+
+use Bluerock\Sellsy\Entities\Entity;
+
+/**
+ * The Time tracking Entity.
+ *
+ * @package bluerock/sellsy-client
+ * @author Jérémie <jeremie@kiwik.com>
+ * @author Thomas <thomas@bluerocktel.com>
+ * @version 1.4.1
+ * @access public
+ */
+class Timetracking extends Entity
+{
+    /**
+     * Timetracking duration, in seconds.
+     */
+    public int $duration;
+
+    /**
+     * Timetracking service ID related.
+     *
+     * @var int|null
+     */
+    public $service;
+
+    /**
+     * Timetracking service name.
+     */
+    public ?string $name;
+}


### PR DESCRIPTION
Add API calls for the 'comments' endpoints.

Also add a helper to get comments linked to an entity
(There is no '/companies/x/comments' entry. So I did a filtered search on the given entity instead, to mock the same behavior)


```php
# General use (not linked to an entity)

// Get all comments (/!\ paginated results. Only the first 25 are displayed here)
$commentsApi = new CommentsApi();
$allComments = $commentsApi->index()->entities();
print_r($allComments);


# Linked to an entity

// Get a company
$companiesApi = new CompaniesApi();
$companyEntity = $companiesApi->show(58322963)->entity();

// Get all associated comments
$entityCommentsApi = $companyEntity->comments();
$allComments = $entityCommentsApi->index()->entities();
print_r($allComments);


# Example on a contact
$contactEntity = $companyEntity->contacts()->index()->entities()[0];
$contactComments = $contactEntity->comments()->index()->entities();
print_r($contactComments);
```